### PR TITLE
Give the option to remove unresolved links

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ const normalizeLink = (responseClone, link, removeUnresolved) => {
  * @return {Object}
  */
 const resolveResponse = (response, options) => {
+  options = options || {};
   if (!response.items) {
     return [];
   }

--- a/index.js
+++ b/index.js
@@ -68,19 +68,28 @@ const walkMutate = (input, predicate, mutator) => {
   return input;
 };
 
+const normalizeLink = (responseClone, link, removeUnresolved) => {
+  const resolvedLink = getLink(responseClone, link);
+  if (resolvedLink === undefined) {
+    return removeUnresolved ? undefined : link;
+  }
+  return resolvedLink;
+};
+
 /**
  * resolveResponse Function
  * Resolves contentful response to normalized form.
  * @param response
  * @return {Object}
  */
-const resolveResponse = (response) => {
+const resolveResponse = (response, options) => {
   if (!response.items) {
     return [];
   }
-  const customObject = cloneDeep(response);
-  walkMutate(customObject, isLink, link => getLink(customObject, link) || link);
-  return customObject.items;
+  const responseClone = cloneDeep(response);
+  walkMutate(responseClone, isLink, (link) => normalizeLink(responseClone, link, options.removeUnresolved));
+
+  return responseClone.items;
 };
 
 module.exports = resolveResponse;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@contentful/eslint-config-backend": "^6.0.0",
-    "buster": "^0.7.18",
     "chai": "^4.1.1",
     "dirty-chai": "^2.0.1",
     "eslint": "^4.4.1",
@@ -23,7 +22,7 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "mocha": "^3.5.0"
+    "mocha": "^4.1.0"
   },
   "author": "Contentful GmbH",
   "license": "MIT",


### PR DESCRIPTION
This PR exposes an `options` params to the `resolveResponse` function and gives the user the possibility to remove an unresolved link