### PR TITLE
fix(resolve): only resolve links within fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ const resolveResponse = (response, options) => {
 
   allEntries
     .forEach((item) => {
-      return Object.assign(item, {
+      Object.assign(item, {
         fields: walkMutate(item.fields, isLink, (link) => normalizeLink(allEntries, link, options.removeUnresolved))
       });
     });

--- a/index.js
+++ b/index.js
@@ -15,9 +15,6 @@ const isLink = (object) => object && object.sys && object.sys.type === 'Link';
  * @return {*}
  */
 const findNormalizableLinkInArray = (array, predicate) => {
-  if (!array) {
-    return undefined;
-  }
   for (let i = 0, len = array.length; i < len; i++) {
     if (predicate(array[i])) {
       return array[i];
@@ -66,7 +63,7 @@ const walkMutate = (input, predicate, mutator) => {
 const normalizeLink = (allEntries, link, removeUnresolved) => {
   const resolvedLink = getLink(allEntries, link);
   if (resolvedLink === undefined) {
-    return removeUnresolved && isLink(link) ? undefined : link;
+    return removeUnresolved ? undefined : link;
   }
   return resolvedLink;
 };
@@ -91,11 +88,11 @@ const resolveResponse = (response, options) => {
   const allEntries = [...responseClone.items, ...allIncludes];
 
   allEntries
-    .forEach((item) => (
-      Object.assign(item, {
+    .forEach((item) => {
+      return Object.assign(item, {
         fields: walkMutate(item.fields, isLink, (link) => normalizeLink(allEntries, link, options.removeUnresolved))
-      })
-    ));
+      });
+    });
 
   return responseClone.items;
 };


### PR DESCRIPTION
What it does:

* Test titles are now more clear about what they actually test
* Minimal code style adjustments (added missing empty lines for consistency)
* Only links within fields will be resolved. Fixes `sys.space` getting set to `undefined` if given `removeUnresolved: true` and improves speed since less properties are walked through
* Adds a new test to ensure only fields are touched
* Fixes one test which actually was testing an invalid response structure (`response with links matching items from includes should be resolved`)

Will fix https://github.com/contentful/contentful.js/issues/214