### PR TITLE
build(esm): provide esm version for bundlers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,28 @@
+{
+  "env": {
+    "esm": {
+      "presets": [
+        ["env", {
+          "targets": {
+            "browsers": [
+              "last 2 versions"
+            ]
+          },
+          "modules": false
+        }]
+      ]
+    },
+    "cjs": {
+      "presets": [
+        ["env", {
+          "targets": {
+            "node": "4.7.2"
+          }
+        }]
+      ],
+      "plugins": [
+        "add-module-exports"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage.lcov
+dist
 
 # Created by https://www.gitignore.io/api/vim,code,linux,macos,windows,sublimetext,node
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const cloneDeep = require('lodash/cloneDeep');
+import cloneDeep from 'lodash/cloneDeep';
 
 /**
  * isLink Function
@@ -132,4 +132,4 @@ const resolveResponse = (response, options) => {
   return responseClone.items;
 };
 
-module.exports = resolveResponse;
+export default resolveResponse;

--- a/package.json
+++ b/package.json
@@ -2,22 +2,36 @@
   "name": "contentful-resolve-response",
   "version": "1.1.0",
   "description": "",
-  "main": "index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "jsnext:main": "./dist/esm/index.js",
   "scripts": {
-    "lint": "eslint '**/*.js'",
+    "build": "BABEL_ENV=cjs babel index.js -d dist/cjs/ && BABEL_ENV=esm babel index.js -d dist/esm/",
+    "lint": "eslint index.js test",
     "test": "npm run lint && npm run test-unit",
-    "test-unit": "nyc mocha 'test/**/*-test.js'",
+    "test-unit": "BABEL_ENV=cjs nyc mocha --require babel-register 'test/**/*-test.js'",
     "test-watch": "npm run test-unit -- --watch",
     "test-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "precommit": "npm run lint",
-    "prepush": "npm run test"
+    "prepush": "npm run test",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",
     "url": "git@github.com:contentful/contentful-resolve-response.git"
   },
+  "engines": {
+    "node": ">=4.7.2"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4"
+  },
   "devDependencies": {
     "@contentful/eslint-config-backend": "^6.0.0",
+    "babel-cli": "^6.26.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-env": "^1.6.1",
+    "babel-register": "^6.26.0",
     "chai": "^4.1.1",
     "codecov": "^3.0.0",
     "dirty-chai": "^2.0.1",
@@ -31,13 +45,13 @@
     "mocha": "^4.1.0",
     "nyc": "^11.4.1"
   },
+  "files": [
+    "dist"
+  ],
   "author": "Contentful GmbH",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com:contentful/contentful-resolve-response/issues"
   },
-  "homepage": "https://github.com:contentful/contentful-resolve-response",
-  "dependencies": {
-    "lodash": "^4.17.4"
-  }
+  "homepage": "https://github.com:contentful/contentful-resolve-response"
 }


### PR DESCRIPTION
Fixes https://github.com/contentful/contentful.js/issues/223

Node users can still just require the plugin, it will pick the commonjs version. (Thats why `babel-plugin-add-module-exports` is needed)

Bundlers will use the `jsnext:main` or `modules` version which is browser compatible ecmascript with modules syntax to allow tree shaking. 