### PR TITLE
fix(compatibility): includes instead of indexOf

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ const makeEntryObject = (item, itemEntryPoints) => {
     return item;
   }
 
-  const entryPoints = Object.keys(item).filter((ownKey) => itemEntryPoints.includes(ownKey));
+  const entryPoints = Object.keys(item).filter((ownKey) => itemEntryPoints.indexOf(ownKey) !== -1 );
 
   return entryPoints.reduce((entryObj, entryPoint) => {
     entryObj[entryPoint] = item[entryPoint];

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ const makeEntryObject = (item, itemEntryPoints) => {
     return item;
   }
 
-  const entryPoints = Object.keys(item).filter((ownKey) => itemEntryPoints.indexOf(ownKey) !== -1 );
+  const entryPoints = Object.keys(item).filter((ownKey) => itemEntryPoints.indexOf(ownKey) !== -1);
 
   return entryPoints.reduce((entryObj, entryPoint) => {
     entryObj[entryPoint] = item[entryPoint];


### PR DESCRIPTION
babel-preset-env can not detect variable types so does not transpile `Array.includes`.

--> https://github.com/babel/babel-preset-env/issues/318