### PR TITLE
feat: remove lodash and replace cloneDeep with fast-copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import copy from 'fast-copy'
 
 const UNRESOLVED_LINK = {} // unique object to avoid polyfill bloat using Symbol()
 
@@ -111,7 +111,7 @@ const resolveResponse = (response, options) => {
   if (!response.items) {
     return []
   }
-  const responseClone = cloneDeep(response)
+  const responseClone = copy(response)
   const allIncludes = Object.keys(responseClone.includes || {}).reduce(
     (all, type) => [...all, ...response.includes[type]],
     []

--- a/package-lock.json
+++ b/package-lock.json
@@ -5297,6 +5297,11 @@
         "is-extglob": "^1.0.0"
       }
     },
+    "fast-copy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.0.tgz",
+      "integrity": "sha512-j4VxAVJsu9NHveYrIj0+nJxXe2lOlibKTlyy0jH8DBwcuV6QyXTy0zTqZhmMKo7EYvuaUk/BFj/o6NU6grE5ag=="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -7353,7 +7358,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=4.7.2"
   },
   "dependencies": {
-    "lodash": "^4.17.15"
+    "fast-copy": "^2.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.0.1",


### PR DESCRIPTION
One of the required steps to fix contentful/contentful.js#408 by removing lodash entirely.
`cloneDeep` has been replaced by https://github.com/planttheidea/fast-copy