### PR TITLE
fix(dep): Bump fast-copy to 2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "contentful-resolve-response",
       "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
-        "fast-copy": "^2.1.1"
+        "fast-copy": "^2.1.3"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=4.7.2"
   },
   "dependencies": {
-    "fast-copy": "^2.1.1"
+    "fast-copy": "^2.1.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",


### PR DESCRIPTION
Bump fast-copy to 2.1.3 to avoid problems in contentful.js caused by an older version: https://github.com/contentful/contentful.js/pull/1216