### PR TITLE
fix: lock fast-copy dependency [NONE]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     commit-message:
       prefix: build
       include: scope
+    ignore:
+      - dependency-name: "fast-copy"
+          # version 3.x is causing import errors on depending packages
+        versions:
+        - ">=3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
-        "fast-copy": "^3.0.0"
+        "fast-copy": "^2.1.7"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.2.1",
@@ -5273,9 +5273,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -18548,9 +18548,9 @@
       }
     },
     "fast-copy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=4.7.2"
   },
   "dependencies": {
-    "fast-copy": "^3.0.0"
+    "fast-copy": "^2.1.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",


### PR DESCRIPTION
[Downstream consumers](https://github.com/contentful/contentful.js/pull/1475) can't handle `fast-copy@3.x` for now. Locking the dependency version to `2.x` for now.