### PR TITLE
fix: don't use regex named groups [DANTE-852]

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ const getResolvedLink = (entityMap, link) => {
     if (!regExp.test(urn)) {
       return UNRESOLVED_LINK
     }
-    const [ _, spaceId, entryId ] = urn.match(regExp)
+    const [_, spaceId, entryId] = urn.match(regExp)
     const extractedLinkType = linkType.split(':')[1]
     return lookupInEntityMap(entityMap, { linkType: extractedLinkType, entryId, spaceId }) || UNRESOLVED_LINK
   }

--- a/index.js
+++ b/index.js
@@ -60,11 +60,11 @@ const getResolvedLink = (entityMap, link) => {
   const { type, linkType } = link.sys
   if (type === 'ResourceLink') {
     const { urn } = link.sys
-    const regExp = /.*:spaces\/(?<spaceId>[A-Za-z0-9]*)\/entries\/(?<entryId>[A-Za-z0-9]*)/
+    const regExp = /.*:spaces\/([A-Za-z0-9]*)\/entries\/([A-Za-z0-9]*)/
     if (!regExp.test(urn)) {
       return UNRESOLVED_LINK
     }
-    const { spaceId, entryId } = urn.match(regExp).groups
+    const [ _, spaceId, entryId ] = urn.match(regExp)
     const extractedLinkType = linkType.split(':')[1]
     return lookupInEntityMap(entityMap, { linkType: extractedLinkType, entryId, spaceId }) || UNRESOLVED_LINK
   }


### PR DESCRIPTION
We're consuming the package in contentful.js which needs to support es2017, i.e. no named regex groups. I'm extracting `spaceId` and `entryId` from xspace links without using those.