### PR TITLE
fix: guard against missing sys in included entities

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ const resolveResponse = (response, options) => {
     []
   )
 
-  const allEntries = [...responseClone.items, ...allIncludes]
+  const allEntries = [...responseClone.items, ...allIncludes].filter((entity) => Boolean(entity.sys))
 
   const entityMap = new Map(
     allEntries.reduce((acc, entity) => {

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -1011,4 +1011,37 @@ describe('Resolve a', function () {
     deepEqual(resolved[0].fields.crossSpaceReference['en-US'], includes.Entry[0])
     deepEqual(resolved[0].fields.crossSpaceReference['de-DE'], includes.Entry[1])
   })
+
+  it(`can not resolve entities without sys property`, () => {
+    const items = [
+      {
+        sys: {
+          type: 'Entry',
+          locale: 'en-US',
+          space: {
+            sys: {
+              type: 'Link',
+              linkType: 'Space',
+              id: 'someSpaceId',
+            },
+          },
+        },
+        fields: {
+          animal: { sys: { type: 'Link', linkType: 'Animal', id: 'oink' } },
+        },
+      },
+    ]
+    const includes = {
+      Animal: [
+        {
+          fields: {
+            name: 'Pig',
+          },
+        },
+      ],
+    }
+
+    const resolved = resolveResponse({ items, includes })
+    deepEqual(resolved, items)
+  })
 })


### PR DESCRIPTION
In case there is an included entity that does not adhere to our existing schema of providing the necessary glue via a `sys` property, we should not fail.