### PR TITLE
fix: update eslint-plugin-mocha config structure [DX-90]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,5 +4,5 @@ import mochaPlugin from 'eslint-plugin-mocha'
 export default [
   { ignores: ['node_modules', 'dist'], files: ['index.js', 'test/**/*.js'] },
   js.configs.recommended,
-  mochaPlugin.configs.flat.recommended,
+  mochaPlugin.configs.recommended,
 ]


### PR DESCRIPTION
## Summary

The lint CI check was failing after [this PR](https://github.com/contentful/contentful-resolve-response/commit/e4ae041e35049ef03c9713e11dc1461b3e2537d8) upgrading `eslint-plugin-mocha`. In looking at the changes in the new version, the config structure changed from `mochaPlugin.configs.flat.recommended` to `mochaPlugin.configs.recommended` ([more info here](https://github.com/lo1tuma/eslint-plugin-mocha/pull/372#discussion_r2065389599)). This PR implements this change so that the lint check passes again.