### PR TITLE
chore: remove team tundra from CODEOWNERS [DX-5]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @contentful/team-tundra @contentful/team-developer-experience
+* @contentful/team-developer-experience
 
 package.json
 package-lock.json


### PR DESCRIPTION
## Summary

Removes `team-tundra` from `CODEOWNERS` file.