### PR TITLE
feat!: Drop support for Node <= 22 [DX-1210] BREAKING CHANGE

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,7 @@
       "presets": [
         ["@babel/preset-env", {
           "targets": {
-            "node": "4.7.2"
+            "node": "22"
           }
         }]
       ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git@github.com:contentful/contentful-resolve-response.git"
   },
   "engines": {
-    "node": ">=4.7.2"
+    "node": ">=22"
   },
   "dependencies": {
     "fast-copy": "^3.0.2"
@@ -87,6 +87,10 @@
         "@semantic-release/commit-analyzer",
         {
           "releaseRules": [
+            {
+              "breaking": true,
+              "release": "major"
+            },
             {
               "type": "build",
               "scope": "deps",


### PR DESCRIPTION
## Summary

BREAKING CHANGE: drop support for node <= 22

Raises the `@babel/preset-env` CJS transpilation target from `node: 4.7.2` (EOL April 2018) to `node: 22`. This is a follow-up to #547, which migrated the Babel toolchain from v6 to v7.


### Why this is a breaking change

The CJS bundle in `dist/cjs/` previously compiled down to ES5 to support Node 4+. With a Node 24 target, `@babel/preset-env` passes modern syntax through as-is (arrow functions, destructuring, template literals, etc.) since Node 24 supports all of it natively. Any consumer running Node <24 may encounter syntax errors from the distributed CJS bundle.

## Test plan

- [x] `npm run build` — CJS and ESM compile successfully
- [x] `npm test` — all 22 tests pass
- [x] `npm run lint` — no lint errors

## Merge order

This PR depends on #547 (Babel v6 → v7) and should be merged after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR raises the Babel CommonJS transpilation target from Node 4.7.2 to Node 22, updating both the `.babelrc` preset-env configuration and the `package.json` engine requirements. The change allows modern JavaScript syntax to pass through untranspiled in the distributed CJS bundle, reducing bundle complexity while dropping support for Node versions below 22.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates `.babelrc` @babel/preset-env targets.node from "4.7.2" to "22", allowing modern syntax (arrow functions, destructuring, template literals) to pass through untranspiled in the CJS bundle</li>

<li>Updates `package.json` engines.node from ">=4.7.2" to ">=22" to formally declare the new minimum supported Node version</li>

<li>Adds breaking change detection rule to semantic-release configuration, triggering major releases for commits marked as breaking</li>

</ul>
</details>

</div>