### PR TITLE
chore: cap fast-copy to v3 [MEC-3447]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
       "description": "version 5.x is ESM only"
     },
     {
+      "matchPackageNames": ["fast-copy"],
+      "allowedVersions": "< 4",
+      "description": "v4 changed to named export only — requires a usage audit before upgrading"
+    },
+    {
       "matchPackageNames": ["semantic-release"],
       "allowedVersions": "< 26"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,7 @@
     },
     {
       "matchPackageNames": ["fast-copy"],
-      "allowedVersions": "< 4",
-      "description": "v4 changed to named export only — requires a usage audit before upgrading"
+      "allowedVersions": "< 4"
     },
     {
       "matchPackageNames": ["semantic-release"],


### PR DESCRIPTION
## Summary

- Adds `allowedVersions: "< 4"` for `fast-copy` in `renovate.json`
- v4 switched to named exports only (`import { copy }` instead of a default import), which is a breaking usage change that requires a code audit before upgrading
- Caps Renovate to v3.x patches while gating the major behind a deliberate review

## Test plan

- [ ] Verify `renovate.json` is valid JSON
- [ ] Confirm no other references to `fast-copy` import style need updating before a v4 bump is considered

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Adds a version pinning constraint for the fast-copy package in Renovate configuration to prevent automatic major version upgrades. This safeguards against breaking changes introduced in v4, which requires updating import statements from default imports to named exports.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added allowedVersions constraint "< 4" for fast-copy in renovate.json to block automatic major upgrades pending a code audit</li>

</ul>
</details>

</div>